### PR TITLE
Update vignette link name

### DIFF
--- a/vignettes/methylCC.Rmd
+++ b/vignettes/methylCC.Rmd
@@ -16,7 +16,7 @@ abstract: |
    about the data generation process: quantile normalization
    and quantile normalization between groups.
 vignette: |
-  %\VignetteIndexEntry{The qsmooth user's guide}
+  %\VignetteIndexEntry{The methylCC user's guide}
   %\VignetteEngine{knitr::rmarkdown}
 ---
 


### PR DESCRIPTION
On the Bioc download page, the name of the vignette link is for your other package qsmooth. This should fix it.